### PR TITLE
throw error if dot command fails

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-
+.vs
 *.user
 *.suo
 /DependencyViewer.Common/bin/

--- a/DependencyViewer.Common/Graphing/QuickGraphProcessor.cs
+++ b/DependencyViewer.Common/Graphing/QuickGraphProcessor.cs
@@ -63,7 +63,6 @@ namespace DependencyViewer.Common.Graphing
 		private string GenerateDot()
 		{
 			var graphviz = new GraphvizAlgorithm<int, IEdge<int>>(_graph);
-			graphviz.GraphFormat.Size = new Size(100, 100);
 			graphviz.GraphFormat.Ratio = GraphvizRatioMode.Auto;
 			graphviz.FormatVertex += graphviz_FormatVertex;
 			graphviz.FormatEdge += graphviz_FormatEdge;
@@ -75,7 +74,7 @@ namespace DependencyViewer.Common.Graphing
 
 			string text = graphviz.Generate(new FileDotEngine(), "graph");
 
-			return text;
+            return text;
 		}
 
 		private void graphviz_FormatEdge(object sender, FormatEdgeEventArgs<int, IEdge<int>> e)

--- a/DependencyViewer.Common/Graphing/QuickGraphProcessor.cs
+++ b/DependencyViewer.Common/Graphing/QuickGraphProcessor.cs
@@ -74,7 +74,7 @@ namespace DependencyViewer.Common.Graphing
 
 			string text = graphviz.Generate(new FileDotEngine(), "graph");
 
-            return text;
+			return text;
 		}
 
 		private void graphviz_FormatEdge(object sender, FormatEdgeEventArgs<int, IEdge<int>> e)

--- a/DependencyViewer/GraphVizService.cs
+++ b/DependencyViewer/GraphVizService.cs
@@ -22,9 +22,11 @@ namespace DependencyViewer
 			psi.CreateNoWindow = true;
 
 			Process proc = Process.Start(psi);
+
 			string procError = proc.StandardError.ReadToEnd();
 			if (proc == null)
 				throw new Exception("Could not run GraphViz");		
+
 			proc.WaitForExit();
 			if (procError != "")
 				throw new Exception(procError);

--- a/DependencyViewer/GraphVizService.cs
+++ b/DependencyViewer/GraphVizService.cs
@@ -13,8 +13,8 @@ namespace DependencyViewer
 			if(fi.Exists == false) throw new ArgumentException("dot file does not exist - " + dotFile);
 
 			ProcessStartInfo psi = new ProcessStartInfo(Settings.Default.GraphVizPath);
-            psi.RedirectStandardError = true;
-            psi.Arguments += "-Tpng";
+			psi.RedirectStandardError = true;
+			psi.Arguments += "-Tpng";
 			psi.Arguments += " -o"+outputFilename;
 			psi.Arguments += " \"" + dotFile + "\"";
 			psi.WindowStyle = ProcessWindowStyle.Hidden;
@@ -22,12 +22,12 @@ namespace DependencyViewer
 			psi.CreateNoWindow = true;
 
 			Process proc = Process.Start(psi);
-            string procError = proc.StandardError.ReadToEnd();
+			string procError = proc.StandardError.ReadToEnd();
 			if (proc == null)
 				throw new Exception("Could not run GraphViz");		
 			proc.WaitForExit();
-            if (procError != "")
-                throw new Exception(procError);
+			if (procError != "")
+				throw new Exception(procError);
 		}
 	}
 }

--- a/DependencyViewer/GraphVizService.cs
+++ b/DependencyViewer/GraphVizService.cs
@@ -27,7 +27,7 @@ namespace DependencyViewer
 			if (proc == null)
 				throw new Exception("Could not run GraphViz");
 		
-            proc.WaitForExit();
+			proc.WaitForExit();
 			if (procError != "")
 				throw new Exception(procError);
 		}

--- a/DependencyViewer/GraphVizService.cs
+++ b/DependencyViewer/GraphVizService.cs
@@ -25,9 +25,9 @@ namespace DependencyViewer
 
 			string procError = proc.StandardError.ReadToEnd();
 			if (proc == null)
-				throw new Exception("Could not run GraphViz");		
-
-			proc.WaitForExit();
+				throw new Exception("Could not run GraphViz");
+		
+            proc.WaitForExit();
 			if (procError != "")
 				throw new Exception(procError);
 		}

--- a/DependencyViewer/GraphVizService.cs
+++ b/DependencyViewer/GraphVizService.cs
@@ -13,7 +13,8 @@ namespace DependencyViewer
 			if(fi.Exists == false) throw new ArgumentException("dot file does not exist - " + dotFile);
 
 			ProcessStartInfo psi = new ProcessStartInfo(Settings.Default.GraphVizPath);
-			psi.Arguments += "-Tpng";
+            psi.RedirectStandardError = true;
+            psi.Arguments += "-Tpng";
 			psi.Arguments += " -o"+outputFilename;
 			psi.Arguments += " \"" + dotFile + "\"";
 			psi.WindowStyle = ProcessWindowStyle.Hidden;
@@ -21,11 +22,12 @@ namespace DependencyViewer
 			psi.CreateNoWindow = true;
 
 			Process proc = Process.Start(psi);
-
+            string procError = proc.StandardError.ReadToEnd();
 			if (proc == null)
-				throw new Exception("Could not run GraphViz");
-		
+				throw new Exception("Could not run GraphViz");		
 			proc.WaitForExit();
+            if (procError != "")
+                throw new Exception(procError);
 		}
 	}
 }


### PR DESCRIPTION
throw error if dot command fails; 

Also, I find a bug:
Dot command syntax does not allow declaring two graph attribute on the same line. Maybe it is syntax for new version of graphviz (2.38). Therefore, default configuration of this problem does not work as expected. I remove one line of code which sets `size (100,100)` and the generated `graph.dot` has the correct syntax then.
